### PR TITLE
Changed the sample main code generated by Kinc/make --init

### DIFF
--- a/out/init.js
+++ b/out/init.js
@@ -20,7 +20,7 @@ function run(name, from) {
     if (!fs.existsSync(path.join(from, 'Sources', 'main.cpp'))) {
         let mainsource = '#include <Kore/pch.h>\n\n'
             + '\n'
-            + 'int kore(int argc, char** argv) {\n'
+            + 'int kickstart(int argc, char** argv) {\n'
             + '\treturn 0;\n'
             + '}\n';
         fs.writeFileSync(path.join(from, 'Sources', 'main.cpp'), mainsource, { encoding: 'utf8' });

--- a/src/init.ts
+++ b/src/init.ts
@@ -23,7 +23,7 @@ export function run(name: string, from: string) {
 	if (!fs.existsSync(path.join(from, 'Sources', 'main.cpp'))) {
 		let mainsource = '#include <Kore/pch.h>\n\n'
 			+ '\n'
-			+ 'int kore(int argc, char** argv) {\n'
+			+ 'int kickstart(int argc, char** argv) {\n'
 			+ '\treturn 0;\n'
 			+ '}\n';
 		fs.writeFileSync(path.join(from, 'Sources', 'main.cpp'), mainsource, { encoding: 'utf8' });


### PR DESCRIPTION
The sample code used by Kinc/make --init wasn't compiling.
New Kinc api expects the signature:
`int kickstart(int argc, char** argv)`
Changed the init.ts file to reflect this api change.