### PR TITLE
Use project.name for path

### DIFF
--- a/out/main.js
+++ b/out/main.js
@@ -340,7 +340,7 @@ function compileProject(make, project, solutionName, options, dothemath) {
                 }
                 if (options.run) {
                     if ((options.customTarget && options.customTarget.baseTarget === Platform_1.Platform.OSX) || options.target === Platform_1.Platform.OSX) {
-                        child_process.spawn('open', ['build/Release/' + solutionName + '.app/Contents/MacOS/' + solutionName], { stdio: 'inherit', cwd: options.to });
+                        child_process.spawn('open', ['build/Release/' + project.name + '.app/Contents/MacOS/' + project.name], { stdio: 'inherit', cwd: options.to });
                     }
                     else if ((options.customTarget && (options.customTarget.baseTarget === Platform_1.Platform.Linux || options.customTarget.baseTarget === Platform_1.Platform.Windows)) || options.target === Platform_1.Platform.Linux || options.target === Platform_1.Platform.Windows) {
                         child_process.spawn(path.resolve(options.from.toString(), project.getDebugDir(), solutionName), [], { stdio: 'inherit', cwd: path.resolve(options.from.toString(), project.getDebugDir()) });

--- a/src/main.ts
+++ b/src/main.ts
@@ -367,7 +367,7 @@ function compileProject(make: child_process.ChildProcess, project: Project, solu
 				}
 				if (options.run) {
 					if ((options.customTarget && options.customTarget.baseTarget === Platform.OSX) || options.target === Platform.OSX) {
-						child_process.spawn('open', ['build/Release/' + solutionName + '.app/Contents/MacOS/' + solutionName], {stdio: 'inherit', cwd: options.to});
+						child_process.spawn('open', ['build/Release/' + project.name + '.app/Contents/MacOS/' + project.name], {stdio: 'inherit', cwd: options.to});
 					}
 					else if ((options.customTarget && (options.customTarget.baseTarget === Platform.Linux || options.customTarget.baseTarget === Platform.Windows)) || options.target === Platform.Linux || options.target === Platform.Windows) {
 						child_process.spawn(path.resolve(options.from.toString(), project.getDebugDir(), solutionName), [], {stdio: 'inherit', cwd: path.resolve(options.from.toString(), project.getDebugDir())});


### PR DESCRIPTION
Not sure if this is fine, or there is way to set executable name as `My-proj` instead of `My proj`, without changing `My proj` for app window.