### PR TITLE
changed libname in AndroidManifest

### DIFF
--- a/Data/android/main/AndroidManifest.xml
+++ b/Data/android/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 			android:screenOrientation="{screenOrientation}"
 			android:launchMode="singleTask"
 			android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen">
-			<meta-data android:name="android.app.lib_name" android:value="kore" />
+			<meta-data android:name="android.app.lib_name" android:value="kinc" />
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 				<category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
When building a Kha project using the `node Kha/make android-native` target, the app crashes at launch because AndroidManifest uses the lib name "kore", but the built library is named "kinc", so it can't find the correct lib.