### PR TITLE
Remove unused linking arguments in LinuxExporter.

### DIFF
--- a/out/Exporters/LinuxExporter.js
+++ b/out/Exporters/LinuxExporter.js
@@ -122,7 +122,7 @@ class LinuxExporter extends Exporter_1.Exporter {
             if (precompiledHeader !== null) {
                 let realfile = path.relative(outputPath, path.resolve(from, file.file));
                 this.p(path.basename(realfile) + '.gch: ' + realfile);
-                this.p('\t' + cppCompiler + ' ' + cpp + ' ' + optimization + ' $(INC) $(DEF) -c ' + realfile + ' -o ' + path.basename(file.file) + '.gch $(LIB)');
+                this.p('\t' + cppCompiler + ' ' + cpp + ' ' + optimization + ' $(INC) $(DEF) -c ' + realfile + ' -o ' + path.basename(file.file) + '.gch');
             }
         }
         for (let fileobject of project.getFiles()) {
@@ -142,7 +142,7 @@ class LinuxExporter extends Exporter_1.Exporter {
                     compiler = cCompiler;
                     flags = '';
                 }
-                this.p('\t' + compiler + ' ' + cpp + ' ' + optimization + ' $(INC) $(DEF) ' + flags + ' -c ' + realfile + ' -o ' + name + '.o $(LIB)');
+                this.p('\t' + compiler + ' ' + cpp + ' ' + optimization + ' $(INC) $(DEF) ' + flags + ' -c ' + realfile + ' -o ' + name + '.o');
             }
         }
         // project.getDefines()

--- a/src/Exporters/LinuxExporter.ts
+++ b/src/Exporters/LinuxExporter.ts
@@ -137,7 +137,7 @@ export class LinuxExporter extends Exporter {
 			if (precompiledHeader !== null) {
 				let realfile = path.relative(outputPath, path.resolve(from, file.file));
 				this.p(path.basename(realfile) + '.gch: ' + realfile);
-				this.p('\t' + cppCompiler + ' ' + cpp + ' ' + optimization + ' $(INC) $(DEF) -c ' + realfile + ' -o ' + path.basename(file.file) + '.gch $(LIB)');
+				this.p('\t' + cppCompiler + ' ' + cpp + ' ' + optimization + ' $(INC) $(DEF) -c ' + realfile + ' -o ' + path.basename(file.file) + '.gch');
 			}
 		}
 
@@ -160,7 +160,7 @@ export class LinuxExporter extends Exporter {
 					flags = '';
 				}
 
-				this.p('\t' + compiler + ' ' + cpp + ' ' + optimization + ' $(INC) $(DEF) ' + flags + ' -c ' + realfile + ' -o ' + name + '.o $(LIB)');
+				this.p('\t' + compiler + ' ' + cpp + ' ' + optimization + ' $(INC) $(DEF) ' + flags + ' -c ' + realfile + ' -o ' + name + '.o');
 			}
 		}
 


### PR DESCRIPTION
Currently, the object files compile commands appends linking directives.
Those directives will be ignored by the compiler, but the compiler will
through a lot of `-Wunused-command-line-argument` warnings.

This patch removes those unused arguments to avoid the warnings.