### PR TITLE
Run in existing shell on macos

### DIFF
--- a/out/main.js
+++ b/out/main.js
@@ -406,7 +406,7 @@ function compileProject(make, project, solutionName, options, dothemath) {
                 }
                 if (options.run) {
                     if ((options.customTarget && options.customTarget.baseTarget === Platform_1.Platform.OSX) || options.target === Platform_1.Platform.OSX) {
-                        child_process.spawn('open', ['build/Release/' + project.name + '.app/Contents/MacOS/' + project.name], { stdio: 'inherit', cwd: options.to });
+                        child_process.spawn('build/Release/' + project.name + '.app/Contents/MacOS/' + project.name, { stdio: 'inherit', cwd: options.to });
                     }
                     else if ((options.customTarget && (options.customTarget.baseTarget === Platform_1.Platform.Linux || options.customTarget.baseTarget === Platform_1.Platform.Windows)) || options.target === Platform_1.Platform.Linux || options.target === Platform_1.Platform.Windows) {
                         child_process.spawn(path.resolve(options.from.toString(), project.getDebugDir(), solutionName), [], { stdio: 'inherit', cwd: path.resolve(options.from.toString(), project.getDebugDir()) });

--- a/src/main.ts
+++ b/src/main.ts
@@ -438,7 +438,7 @@ function compileProject(make: child_process.ChildProcess, project: Project, solu
 				}
 				if (options.run) {
 					if ((options.customTarget && options.customTarget.baseTarget === Platform.OSX) || options.target === Platform.OSX) {
-						child_process.spawn('open', ['build/Release/' + project.name + '.app/Contents/MacOS/' + project.name], {stdio: 'inherit', cwd: options.to});
+						child_process.spawn('build/Release/' + project.name + '.app/Contents/MacOS/' + project.name, {stdio: 'inherit', cwd: options.to});
 					}
 					else if ((options.customTarget && (options.customTarget.baseTarget === Platform.Linux || options.customTarget.baseTarget === Platform.Windows)) || options.target === Platform.Linux || options.target === Platform.Windows) {
 						child_process.spawn(path.resolve(options.from.toString(), project.getDebugDir(), solutionName), [], {stdio: 'inherit', cwd: path.resolve(options.from.toString(), project.getDebugDir())});


### PR DESCRIPTION
On a Mac, when running my Kha Project through `node Kha/make.js --run`, it kept opening a terminal window that I needed to manually close each time I closed the application after I was done with it. I found this a bit annoying and attempted to fix it with this PR.