### PR TITLE
Add correct shader lang for FreeBSD target

### DIFF
--- a/out/main.js
+++ b/out/main.js
@@ -139,6 +139,16 @@ function shaderLang(platform) {
             return 'essl';
         case Platform_1.Platform.Pi:
             return 'essl';
+        case Platform_1.Platform.FreeBSD:
+            switch (Options_1.Options.graphicsApi) {
+                case GraphicsApi_1.GraphicsApi.Vulkan:
+                    return 'spirv';
+                case GraphicsApi_1.GraphicsApi.OpenGL:
+                case GraphicsApi_1.GraphicsApi.Default:
+                    return 'glsl';
+                default:
+                    throw new Error('Unsupported shader language.');
+            }
         default:
             return platform;
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -144,6 +144,16 @@ function shaderLang(platform: string): string {
 			return 'essl';
 		case Platform.Pi:
 			return 'essl';
+		case Platform.FreeBSD:
+			switch (Options.graphicsApi) {
+				case GraphicsApi.Vulkan:
+					return 'spirv';
+				case GraphicsApi.OpenGL:
+				case GraphicsApi.Default:
+					return 'glsl';
+				default:
+					throw new Error('Unsupported shader language.');
+			}
 		default:
 			return platform;
 	}


### PR DESCRIPTION
The `shaderLang` function returned the platform name in the case of FreeBSD as detected platform instead of the proper shader language.